### PR TITLE
Update content on initial pages

### DIFF
--- a/app/forms/HasTradingNameFormProvider.scala
+++ b/app/forms/HasTradingNameFormProvider.scala
@@ -23,8 +23,8 @@ import play.api.data.Form
 
 class HasTradingNameFormProvider @Inject() extends Mappings {
 
-  def apply(): Form[Boolean] =
+  def apply(registeredCompanyName: String): Form[Boolean] =
     Form(
-      "value" -> boolean("hasTradingName.error.required")
+      "value" -> boolean("hasTradingName.error.required", args = Seq(registeredCompanyName))
     )
 }

--- a/app/viewmodels/checkAnswers/HasTradingNameSummary.scala
+++ b/app/viewmodels/checkAnswers/HasTradingNameSummary.scala
@@ -18,7 +18,7 @@ package viewmodels.checkAnswers
 
 import controllers.routes
 import models.{CheckMode, UserAnswers}
-import pages.HasTradingNamePage
+import pages.{HasTradingNamePage, RegisteredCompanyNamePage}
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist._
@@ -27,18 +27,20 @@ import viewmodels.implicits._
 object HasTradingNameSummary  {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
-    answers.get(HasTradingNamePage).map {
-      answer =>
+    for {
+      hasTradingName        <- answers.get(HasTradingNamePage)
+      registeredCompanyName <- answers.get(RegisteredCompanyNamePage)
+    } yield {
 
-        val value = if (answer) "site.yes" else "site.no"
+      val value = if (hasTradingName) "site.yes" else "site.no"
 
-        SummaryListRowViewModel(
-          key     = "hasTradingName.checkYourAnswersLabel",
-          value   = ValueViewModel(value),
-          actions = Seq(
-            ActionItemViewModel("site.change", routes.HasTradingNameController.onPageLoad(CheckMode).url)
-              .withVisuallyHiddenText(messages("hasTradingName.change.hidden"))
-          )
+      SummaryListRowViewModel(
+        key     = messages("hasTradingName.checkYourAnswersLabel", registeredCompanyName),
+        value   = ValueViewModel(value),
+        actions = Seq(
+          ActionItemViewModel("site.change", routes.HasTradingNameController.onPageLoad(CheckMode).url)
+            .withVisuallyHiddenText(messages("hasTradingName.change.hidden", registeredCompanyName))
         )
+      )
     }
 }

--- a/app/views/HasTradingNameView.scala.html
+++ b/app/views/HasTradingNameView.scala.html
@@ -22,7 +22,7 @@
     govukButton: GovukButton
 )
 
-@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], mode: Mode, registeredCompanyName: String)(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = title(form, messages("hasTradingName.title"))) {
 
@@ -35,7 +35,7 @@
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),
-                legend = LegendViewModel(messages("hasTradingName.heading")).asPageHeading()
+                legend = LegendViewModel(messages("hasTradingName.heading", registeredCompanyName)).asPageHeading()
             )
         )
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1,4 +1,4 @@
-service.name = one-stop-shop-registration-frontend
+service.name = Register for One Stop Shop
 
 site.back = Back
 site.remove = Remove
@@ -56,28 +56,28 @@ signedOut.guidance = We did not save your answers.
 unauthorised.title = You can’t access this service with this account
 unauthorised.heading = You can’t access this service with this account
 
-hasTradingName.title = hasTradingName
-hasTradingName.heading = hasTradingName
-hasTradingName.checkYourAnswersLabel = hasTradingName
-hasTradingName.error.required = Select yes if hasTradingName
-hasTradingName.change.hidden = HasTradingName
+hasTradingName.title = Does your business trade using a different name?
+hasTradingName.heading = Does your business trade using a name other than {0}?
+hasTradingName.checkYourAnswersLabel = Does your business trade using a name other than {0}?
+hasTradingName.error.required = Select yes if your business trades using a name other than {0}
+hasTradingName.change.hidden = if your business trades using a name other than {0}
 
-partOfVatGroup.title = partOfVatGroup
-partOfVatGroup.heading = partOfVatGroup
-partOfVatGroup.checkYourAnswersLabel = partOfVatGroup
-partOfVatGroup.error.required = Select yes if partOfVatGroup
-partOfVatGroup.change.hidden = PartOfVatGroup
+partOfVatGroup.title = Is the business you’re registering part of a VAT group?
+partOfVatGroup.heading = Is the business you’re registering part of a VAT group?
+partOfVatGroup.checkYourAnswersLabel = Is the business you’re registering part of a VAT group?
+partOfVatGroup.error.required = Select yes if the business you’re registering is part of a VAT group
+partOfVatGroup.change.hidden = if the business you’re registering is part of a VAT group
 
-registeredCompanyName.title = registeredCompanyName
-registeredCompanyName.heading = registeredCompanyName
-registeredCompanyName.checkYourAnswersLabel = registeredCompanyName
-registeredCompanyName.error.required = Enter registeredCompanyName
-registeredCompanyName.error.length = RegisteredCompanyName must be 100 characters or less
-registeredCompanyName.change.hidden = RegisteredCompanyName
+registeredCompanyName.title = What is the registered company name?
+registeredCompanyName.heading = What is the registered company name?
+registeredCompanyName.checkYourAnswersLabel = What is the registered company name?
+registeredCompanyName.error.required = Enter the registered company name
+registeredCompanyName.error.length = The registered company name must be 100 characters or less
+registeredCompanyName.change.hidden = the registered company name
 
-tradingName.title = tradingName
-tradingName.heading = tradingName
-tradingName.checkYourAnswersLabel = tradingName
-tradingName.error.required = Enter tradingName
-tradingName.error.length = TradingName must be 100 characters or less
-tradingName.change.hidden = TradingName
+tradingName.title = What is your trading name?
+tradingName.heading = What is your trading name?
+tradingName.checkYourAnswersLabel = What is your trading name?
+tradingName.error.required = Enter your trading name
+tradingName.error.length = Your trading name must be 100 characters or less
+tradingName.change.hidden = your trading name

--- a/test/forms/HasTradingNameFormProviderSpec.scala
+++ b/test/forms/HasTradingNameFormProviderSpec.scala
@@ -23,8 +23,9 @@ class HasTradingNameFormProviderSpec extends BooleanFieldBehaviours {
 
   val requiredKey = "hasTradingName.error.required"
   val invalidKey = "error.boolean"
+  val registeredCompanyName = "foo"
 
-  val form = new HasTradingNameFormProvider()()
+  val form = new HasTradingNameFormProvider()(registeredCompanyName)
 
   ".value" - {
 
@@ -33,13 +34,13 @@ class HasTradingNameFormProviderSpec extends BooleanFieldBehaviours {
     behave like booleanField(
       form,
       fieldName,
-      invalidError = FormError(fieldName, invalidKey)
+      invalidError = FormError(fieldName, invalidKey, Seq(registeredCompanyName))
     )
 
     behave like mandatoryField(
       form,
       fieldName,
-      requiredError = FormError(fieldName, requiredKey)
+      requiredError = FormError(fieldName, requiredKey, Seq(registeredCompanyName))
     )
   }
 }


### PR DESCRIPTION
This PR updates the content to align with the initial journey flows.  It also pulls the registered company name through to the "has trading name" page' heading, errors etc. (but intentionally not the page title, to avoid it being picked up in analytics etc.)